### PR TITLE
🔒 [security fix] Path Traversal in Multiple EPUB Download and Delete

### DIFF
--- a/app/routers/epubs_enhanced.py
+++ b/app/routers/epubs_enhanced.py
@@ -292,6 +292,18 @@ def _chapter_start_of(filename: str) -> int:
     return int(m.group(1)) if m else 0
 
 
+def _get_safe_path(base_dir: str, filename: str) -> Optional[Path]:
+    """Resolve filename against base_dir and ensure it stays within base_dir."""
+    try:
+        base_path = Path(base_dir).resolve()
+        target_path = (base_path / filename).resolve()
+        # Verify that the resolved target path is under the base path
+        target_path.relative_to(base_path)
+        return target_path
+    except (ValueError, RuntimeError):
+        return None
+
+
 @router.post("/epub/cancel")
 def cancel_generation():
     """Cancel ongoing EPUB generation."""
@@ -350,11 +362,11 @@ def download_one_epub_local(name: str):
     """Download single EPUB from local storage."""
     settings = get_settings()
     books_dir = settings.local_storage_path
-    epub_path = os.path.join(books_dir, name)
-    
-    if not os.path.exists(epub_path):
+    epub_path = _get_safe_path(books_dir, name)
+
+    if not epub_path or not epub_path.exists():
         return error("File not found", code="not_found", status=404)
-    return FileResponse(epub_path, filename=name)
+    return FileResponse(str(epub_path), filename=name)
 
 
 @router.post("/epubs/download/one", response_class=StreamingResponse)
@@ -382,13 +394,13 @@ def download_many_epubs_local(req: DownloadManyLocalRequest):
     """Download multiple EPUBs from local storage as ZIP."""
     settings = get_settings()
     books_dir = settings.local_storage_path
-    
+
     buf = BytesIO()
     with zipfile.ZipFile(buf, "w") as zipf:
         for name in req.names:
-            epub_path = os.path.join(books_dir, name)
-            if os.path.exists(epub_path):
-                zipf.write(epub_path, arcname=name)
+            epub_path = _get_safe_path(books_dir, name)
+            if epub_path and epub_path.exists():
+                zipf.write(str(epub_path), arcname=name)
     buf.seek(0)
     return StreamingResponse(buf, media_type="application/zip", headers={"Content-Disposition": "attachment; filename=epubs.zip"})
 
@@ -478,10 +490,10 @@ def delete_many_epubs_local(names: List[str]):
 
     deleted, errors = [], []
     for name in names:
-        epub_path = os.path.join(books_dir, name)
-        if os.path.exists(epub_path):
+        epub_path = _get_safe_path(books_dir, name)
+        if epub_path and epub_path.exists():
             try:
-                os.remove(epub_path)
+                os.remove(str(epub_path))
                 deleted.append(name)
             except Exception as e:
                 errors.append({"name": name, "error": str(e)})

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from typing import Optional
+
+def _get_safe_path(base_dir: str, filename: str) -> Optional[Path]:
+    """Resolve filename against base_dir and ensure it stays within base_dir."""
+    try:
+        base_path = Path(base_dir).resolve()
+        target_path = (base_path / filename).resolve()
+        # Verify that the resolved target path is under the base path
+        target_path.relative_to(base_path)
+        return target_path
+    except (ValueError, RuntimeError):
+        return None
+
+def test_get_safe_path():
+    import os
+    import shutil
+    # Setup
+    base_dir = "test_books"
+    os.makedirs(base_dir, exist_ok=True)
+
+    # Create a dummy file inside base_dir
+    safe_file = Path(base_dir) / "safe.epub"
+    safe_file.touch()
+
+    # Create a dummy file outside base_dir
+    outside_file = Path("outside.txt")
+    outside_file.touch()
+
+    try:
+        # Test valid path
+        res = _get_safe_path(base_dir, "safe.epub")
+        assert res is not None
+        assert res.name == "safe.epub"
+
+        # Test path traversal (absolute)
+        assert _get_safe_path(base_dir, "/etc/passwd") is None
+
+        # Test path traversal (relative)
+        assert _get_safe_path(base_dir, "../outside.txt") is None
+        assert _get_safe_path(base_dir, "../../etc/passwd") is None
+
+        # Test non-existent but safe path
+        assert _get_safe_path(base_dir, "non_existent.epub") is not None
+
+        print("Security tests passed!")
+    finally:
+        # Cleanup
+        shutil.rmtree(base_dir)
+        outside_file.unlink()
+
+if __name__ == "__main__":
+    test_get_safe_path()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR addresses several Path Traversal vulnerabilities in the local storage endpoints of the EPUB converter.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could exploit these vulnerabilities to read sensitive files from the server (e.g., `/etc/passwd`) or delete arbitrary files that the application has permissions to access, by providing specially crafted filenames containing path traversal sequences like `../`.

🛡️ **Solution:** How the fix addresses the vulnerability
A new sanitization helper function `_get_safe_path` has been implemented in `app/routers/epubs_enhanced.py`. This function uses `pathlib.Path` to:
1. Resolve the requested filename against the base storage directory to its absolute path.
2. Verify that the resolved path is still within the intended storage directory using `relative_to()`.

This helper has been applied to the following endpoints:
- `GET /epub/download` (Single download)
- `POST /epub/download-many` (Multiple download as ZIP)
- `DELETE /epubs` (Multiple delete)

The fix is compatible with Python 3.8+ and handles edge cases where requested paths might attempt to escape the `books` directory.

Verification:
- Created `tests/test_logic.py` to verify the `_get_safe_path` logic against various attack payloads (traversal sequences, absolute paths, etc).
- The logic was verified to correctly block traversal while allowing valid access within the storage directory.

---
*PR created automatically by Jules for task [10330117348832621967](https://jules.google.com/task/10330117348832621967) started by @Aditya-AR-A*

## Summary by Sourcery

Harden local EPUB storage operations against path traversal by sanitizing requested filenames and validating them against the storage directory.

Bug Fixes:
- Prevent path traversal in local EPUB download and delete endpoints by resolving and validating file paths within the configured storage directory.

Tests:
- Add security-focused tests for the path resolution helper to ensure traversal attempts and absolute paths are rejected while valid in-directory paths are allowed.