### PR TITLE
⚡ Optimize epub download with concurrent requests

### DIFF
--- a/app/routers/epubs.py
+++ b/app/routers/epubs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import concurrent.futures
 import zipfile
 from io import BytesIO
 from pathlib import Path
@@ -111,9 +112,15 @@ def download_many_epubs(
 
     zip_buffer = BytesIO()
     with zipfile.ZipFile(zip_buffer, "w") as zipf:
-        for record in records:
-            file_buffer = service.download_buffer(record.s3_key)
-            zipf.writestr(Path(record.s3_key).name, file_buffer.getvalue())
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future_to_record = {
+                executor.submit(service.download_buffer, record.s3_key): record
+                for record in records
+            }
+            for future in concurrent.futures.as_completed(future_to_record):
+                record = future_to_record[future]
+                file_buffer = future.result()
+                zipf.writestr(Path(record.s3_key).name, file_buffer.getvalue())
     zip_buffer.seek(0)
 
     headers = {"Content-Disposition": "attachment; filename=epubs.zip"}
@@ -128,9 +135,15 @@ def download_all_epubs(service: EpubService = Depends(get_service)):
 
     zip_buffer = BytesIO()
     with zipfile.ZipFile(zip_buffer, "w") as zipf:
-        for record in records:
-            file_buffer = service.download_buffer(record.s3_key)
-            zipf.writestr(Path(record.s3_key).name, file_buffer.getvalue())
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future_to_record = {
+                executor.submit(service.download_buffer, record.s3_key): record
+                for record in records
+            }
+            for future in concurrent.futures.as_completed(future_to_record):
+                record = future_to_record[future]
+                file_buffer = future.result()
+                zipf.writestr(Path(record.s3_key).name, file_buffer.getvalue())
     zip_buffer.seek(0)
 
     headers = {"Content-Disposition": "attachment; filename=all_epubs.zip"}

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,61 @@
+import time
+import zipfile
+import concurrent.futures
+from io import BytesIO
+from pathlib import Path
+
+class MockRecord:
+    def __init__(self, s3_key):
+        self.s3_key = s3_key
+
+class MockService:
+    def download_buffer(self, s3_key):
+        time.sleep(0.1) # Simulate network delay
+        b = BytesIO(b"dummy data " * 1000)
+        b.seek(0)
+        return b
+
+def baseline(records, service):
+    zip_buffer = BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as zipf:
+        for record in records:
+            file_buffer = service.download_buffer(record.s3_key)
+            zipf.writestr(Path(record.s3_key).name, file_buffer.getvalue())
+    zip_buffer.seek(0)
+    return zip_buffer
+
+def optimized(records, service):
+    zip_buffer = BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as zipf:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future_to_record = {
+                executor.submit(service.download_buffer, record.s3_key): record
+                for record in records
+            }
+            for future in concurrent.futures.as_completed(future_to_record):
+                record = future_to_record[future]
+                file_buffer = future.result()
+                zipf.writestr(Path(record.s3_key).name, file_buffer.getvalue())
+    zip_buffer.seek(0)
+    return zip_buffer
+
+def main():
+    service = MockService()
+    records = [MockRecord(f"epubs/book_{i}.epub") for i in range(20)]
+
+    print("Running baseline...")
+    start = time.time()
+    b_buf = baseline(records, service)
+    t_base = time.time() - start
+    print(f"Baseline: {t_base:.2f}s")
+
+    print("Running optimized...")
+    start = time.time()
+    o_buf = optimized(records, service)
+    t_opt = time.time() - start
+    print(f"Optimized: {t_opt:.2f}s")
+
+    print(f"Improvement: {t_base / t_opt:.2f}x faster")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
💡 **What:** The optimization uses `concurrent.futures.ThreadPoolExecutor` to fetch EPUB files concurrently from the storage service rather than downloading them sequentially. This patch applies the optimization to both `/download/many` and `/download/all` endpoints.
🎯 **Why:** Sequential downloading is inefficient, especially when network delay to the storage service is involved. As the thread blocks while waiting for each download to finish, the response time linearly increases with the number of requested files. Using a thread pool allows I/O bounds requests to run concurrently.
📊 **Measured Improvement:** A simulated benchmark of fetching 20 EPUB files with a 100ms artificial network delay demonstrated a substantial ~6.5x speedup (2.01s baseline vs. 0.31s optimized).

---
*PR created automatically by Jules for task [17340056102012153830](https://jules.google.com/task/17340056102012153830) started by @Aditya-AR-A*

## Summary by Sourcery

Optimize EPUB download endpoints by fetching files concurrently and add a small benchmark script to compare sequential vs concurrent performance.

New Features:
- Enable concurrent EPUB downloads in the /download/many and /download/all endpoints using a thread pool.

Enhancements:
- Introduce a benchmark script to measure performance improvements between sequential and concurrent EPUB downloads.