### PR TITLE
fix: correctly quarantine bad proxies in proxy manager

### DIFF
--- a/scripts/proxy_manager.py
+++ b/scripts/proxy_manager.py
@@ -194,11 +194,11 @@ def fetch_with_proxy_rotation(
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0',
     ]
     for attempt in range(retries):
-        if attempt == 0 and preferred_first_proxy is not None:
+        if attempt == 0 and preferred_first_proxy is not None and (preferred_first_proxy not in _quarantined_until or time.time() > _quarantined_until[preferred_first_proxy]):
             proxy_url = preferred_first_proxy
         elif attempt == 0 and allow_no_proxy and not PRIMARY_PROXY:
             proxy_url = None
-        elif attempt == 1 and allow_no_proxy and not PRIMARY_PROXY:
+        elif attempt == 1 and allow_no_proxy and not PRIMARY_PROXY and preferred_first_proxy is not None:
             proxy_url = None
         else:
             # Build a candidate set avoiding previously attempted and avoid list
@@ -240,14 +240,18 @@ def fetch_with_proxy_rotation(
             last_exc = e
             print(f"[proxy_manager] Blocked for {url} proxy={proxy_url}: {e}")
             if proxy_url:
-                _proxy_failures[proxy_url] = _proxy_failures.get(proxy_url, 0) - 1
+                score = _proxy_failures.get(proxy_url, 0) - 1
+                _proxy_failures[proxy_url] = score
+                if score <= MIN_PROXY_HEALTH:
+                    _quarantined_until[proxy_url] = time.time() + _QUARANTINE_SECONDS
+                    print(f"[proxy_manager] Quarantined {proxy_url} fail_score={score}")
             if SHORT_CIRCUIT_ON_FIRST_403:
                 break
         except Exception as e:
             last_exc = e
             print(f"[proxy_manager] Attempt {attempt+1}/{retries} failed for {url} proxy={proxy_url}: {e}")
             if proxy_url:
-                score = _proxy_failures.get(proxy_url, 0) + 1
+                score = _proxy_failures.get(proxy_url, 0) - 1
                 _proxy_failures[proxy_url] = score
                 if score <= MIN_PROXY_HEALTH:
                     _quarantined_until[proxy_url] = time.time() + _QUARANTINE_SECONDS

--- a/test_proxy_manager.py
+++ b/test_proxy_manager.py
@@ -1,0 +1,10 @@
+from scripts.proxy_manager import fetch_with_proxy_rotation, get_all_proxies, _proxy_failures, _quarantined_until
+import requests
+
+print("Testing direct connection...")
+try:
+    resp = fetch_with_proxy_rotation("https://freewebnovel.com/novel/invalid-url-that-does-not-exist/chapter-1", retries=3)
+except Exception as e:
+    print("Expected exception caught.")
+
+print("_proxy_failures:", _proxy_failures)


### PR DESCRIPTION
This change fixes a bug in the proxy manager where bad proxies were never quarantined because their failure scores were being incorrectly incremented instead of decremented towards the negative threshold. It also ensures quarantined proxies are skipped when provided as a preferred proxy, and removes redundant direct connection attempts.

---
*PR created automatically by Jules for task [14487662021489748713](https://jules.google.com/task/14487662021489748713) started by @Aditya-AR-A*

## Summary by Sourcery

Fix proxy rotation error handling so that failing proxies are correctly penalized and quarantined, and avoid using quarantined proxies as preferred choices.

Bug Fixes:
- Correct proxy failure score updates so that repeated failures decrease health and trigger quarantine when the minimum threshold is reached.
- Skip preferred proxies that are currently quarantined instead of attempting to use them.
- Avoid redundant direct (no-proxy) connection attempts when a preferred proxy is specified.

Tests:
- Add a simple script-based test harness to exercise fetch_with_proxy_rotation and inspect proxy failure tracking state.